### PR TITLE
Do not try to get xattrs for the root inode

### DIFF
--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -462,11 +462,15 @@ func (fs *Goofys) GetXattr(ctx context.Context,
 
 func (fs *Goofys) ListXattr(ctx context.Context,
 	op *fuseops.ListXattrOp) (err error) {
+	var xattrs []string
+
 	fs.mu.RLock()
 	inode := fs.getInodeOrDie(op.Inode)
 	fs.mu.RUnlock()
 
-	xattrs, err := inode.ListXattr()
+	if inode.Id != 1 {
+		xattrs, err = inode.ListXattr()
+	}
 
 	ncopied := 0
 


### PR DESCRIPTION
Otherwise the path in the S3 request is empty, which is invalid.

fixes kahing/goofys#522

Doing the PR here since the kahing version seems not maintained anymore and I am using your fork either way.